### PR TITLE
Local storage for client secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ N5 library implementation using Google Cloud Storage backend.
 ### OAuth 2.0
 This [test](https://github.com/saalfeldlab/n5-google-cloud/blob/master/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/N5GoogleCloudStorageOAuth2Test.java) uses OAuth 2.0 authentication to run unit tests using actual Google Cloud Storage backend. It is excluded from the test run configuration by default and requires a few steps to set up:
 1. Create a project in the [Google Cloud console](https://console.cloud.google.com).
-1. Go to [APIs & services](https://console.cloud.google.com/apis/credentials) and choose *Create credentials* → *OAuth client ID* → *Other*.
-1. Once created, put the provided **client_id** and **client_secret** fields into [src/test/resources/client_secrets.json](https://github.com/saalfeldlab/n5-google-cloud/blob/master/src/test/resources/client_secrets.json).
 1. Enable [Storage API](https://console.cloud.google.com/apis/library/storage-component.googleapis.com) and [Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com).
+1. Go to [APIs & services](https://console.cloud.google.com/apis/credentials) and choose *Create credentials* → *OAuth client ID* → *Other*.
+1. Once created, either download the JSON file with client secrets from the web page, or run `SetGoogleCloudClientSecrets.java` with **client_id** and **client_secret** as arguments to store them in the default location `$user.home/.google/n5-google-cloud`.
 
 This approach allows to obtain temporary security credentials and a refresh token that can be used to obtain new short-term credentials. The [test](https://github.com/saalfeldlab/n5-google-cloud/blob/master/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/N5GoogleCloudStorageOAuth2Test.java) shows how to create a Storage API client in a way that it handles refreshing access tokens internally.
 The refresh token remains valid as long as the user has not revoked application access.

--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudClient.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudClient.java
@@ -1,41 +1,33 @@
 package org.janelia.saalfeldlab.googlecloud;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
-import com.google.auth.oauth2.AccessToken;
-import com.google.auth.oauth2.OAuth2Credentials;
-import com.google.auth.oauth2.UserCredentials;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
-public abstract class GoogleCloudClient {
+import com.google.auth.Credentials;
 
-	private final AccessToken accessToken;
-	private final GoogleClientSecrets clientSecrets;
-	private final String refreshToken;
+public abstract class GoogleCloudClient<T> {
 
-	public GoogleCloudClient(final AccessToken accessToken) {
+	public static interface Scope {
 
-		this(accessToken, null, null);
-	}
+		@Override
+		public String toString();
 
-	public GoogleCloudClient(final AccessToken accessToken, final GoogleClientSecrets clientSecrets, final String refreshToken) {
+		public static Collection<String> toScopeStrings(final Collection<? extends Scope> scopes) {
 
-		this.accessToken = accessToken;
-		this.clientSecrets = clientSecrets;
-		this.refreshToken = refreshToken;
-	}
-
-	protected OAuth2Credentials getCredentials() {
-
-		final OAuth2Credentials credentials;
-		if (clientSecrets == null || refreshToken == null) {
-			credentials = OAuth2Credentials.create(accessToken);
-		} else {
-			credentials = UserCredentials.newBuilder()
-					.setAccessToken(accessToken)
-					.setClientId(clientSecrets.getDetails().getClientId())
-					.setClientSecret(clientSecrets.getDetails().getClientSecret())
-					.setRefreshToken(refreshToken)
-				.build();
+			final List<String> scopeStrings = new ArrayList<>();
+			for (final Scope scope : scopes)
+				scopeStrings.add(scope.toString());
+			return scopeStrings;
 		}
-		return credentials;
 	}
+
+	protected final Credentials credentials;
+
+	public GoogleCloudClient(final Credentials credentials) {
+
+		this.credentials = credentials;
+	}
+
+	public abstract T create();
 }

--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudClientSecretsProvider.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudClientSecretsProvider.java
@@ -36,7 +36,7 @@ public class GoogleCloudClientSecretsProvider {
 	 */
 	public static void save(final Path location, final GoogleClientSecrets clientSecrets) throws IOException {
 
-		location.toFile().mkdirs();
+		location.getParent().toFile().mkdirs();
 		try (final Writer writer = new FileWriter(location.toFile())) {
 			GoogleCloudOAuth.JSON_FACTORY.createJsonGenerator(writer).serialize(clientSecrets);
 		}

--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudClientSecretsProvider.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudClientSecretsProvider.java
@@ -1,0 +1,67 @@
+package org.janelia.saalfeldlab.googlecloud;
+
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Path;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+
+public class GoogleCloudClientSecretsProvider {
+
+	/** Filename to store client secrets. */
+	public static final String CLIENT_SECRETS_FILENAME = ".client";
+
+	/**
+	 * Saves client secrets as a JSON file in the default location.
+	 *
+	 * @param clientId
+	 * @param clientSecret
+	 * @throws IOException
+	 */
+	public static void save(final GoogleClientSecrets clientSecrets) throws IOException {
+
+		save(GoogleCloudOAuth.DATA_STORE_DIR.resolve(CLIENT_SECRETS_FILENAME), clientSecrets);
+	}
+
+	/**
+	 * Saves client secrets as a JSON file in the specified location.
+	 *
+	 * @param location
+	 * @param clientId
+	 * @param clientSecret
+	 * @throws IOException
+	 */
+	public static void save(final Path location, final GoogleClientSecrets clientSecrets) throws IOException {
+
+		location.toFile().mkdirs();
+		try (final Writer writer = new FileWriter(location.toFile())) {
+			GoogleCloudOAuth.JSON_FACTORY.createJsonGenerator(writer).serialize(clientSecrets);
+		}
+	}
+
+	/**
+	 * Loads client secrets from a JSON file in the default location.
+	 *
+	 * @throws IOException
+	 */
+	public static GoogleClientSecrets load() throws IOException {
+
+		return load(GoogleCloudOAuth.DATA_STORE_DIR.resolve(CLIENT_SECRETS_FILENAME));
+	}
+
+	/**
+	 * Loads client secrets from a JSON file in the specified location.
+	 *
+	 * @param location
+	 * @throws IOException
+	 */
+	public static GoogleClientSecrets load(final Path location) throws IOException {
+
+		try (final Reader reader = new FileReader(location.toFile())) {
+			return GoogleClientSecrets.load(GoogleCloudOAuth.JSON_FACTORY, reader);
+		}
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudClientSecretsProvider.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudClientSecretsProvider.java
@@ -8,6 +8,7 @@ import java.io.Writer;
 import java.nio.file.Path;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+import com.google.api.client.json.JsonGenerator;
 
 public class GoogleCloudClientSecretsProvider {
 
@@ -38,7 +39,10 @@ public class GoogleCloudClientSecretsProvider {
 
 		location.getParent().toFile().mkdirs();
 		try (final Writer writer = new FileWriter(location.toFile())) {
-			GoogleCloudOAuth.JSON_FACTORY.createJsonGenerator(writer).serialize(clientSecrets);
+			final JsonGenerator jsonWriter = GoogleCloudOAuth.JSON_FACTORY.createJsonGenerator(writer);
+			jsonWriter.serialize(clientSecrets);
+			jsonWriter.flush();
+			jsonWriter.close();
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudResourceManagerClient.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudResourceManagerClient.java
@@ -1,13 +1,12 @@
 package org.janelia.saalfeldlab.googlecloud;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
-import com.google.auth.oauth2.AccessToken;
+import com.google.auth.Credentials;
 import com.google.cloud.resourcemanager.ResourceManager;
 import com.google.cloud.resourcemanager.ResourceManagerOptions;
 
-public class GoogleCloudResourceManagerClient extends GoogleCloudClient {
+public class GoogleCloudResourceManagerClient extends GoogleCloudClient<ResourceManager> {
 
-	public static enum ProjectsScope implements GoogleCloudOAuth.Scope {
+	public static enum ProjectsScope implements Scope {
 
 		READ_ONLY("https://www.googleapis.com/auth/cloudplatformprojects.readonly"),
 		FULL_CONTROL("https://www.googleapis.com/auth/cloudplatformprojects");
@@ -26,18 +25,16 @@ public class GoogleCloudResourceManagerClient extends GoogleCloudClient {
 		}
 	}
 
-	public GoogleCloudResourceManagerClient(final AccessToken accessToken) {
+	public GoogleCloudResourceManagerClient(final Credentials credentials) {
 
-		super(accessToken);
+		super(credentials);
 	}
 
-	public GoogleCloudResourceManagerClient(final AccessToken accessToken, final GoogleClientSecrets clientSecrets, final String refreshToken) {
-
-		super(accessToken, clientSecrets, refreshToken);
-	}
-
+	@Override
 	public ResourceManager create() {
 
-		return ResourceManagerOptions.newBuilder().setCredentials(getCredentials()).build().getService();
+		return ResourceManagerOptions.newBuilder()
+				.setCredentials(credentials)
+				.build().getService();
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudStorageClient.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudStorageClient.java
@@ -1,13 +1,12 @@
 package org.janelia.saalfeldlab.googlecloud;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
-import com.google.auth.oauth2.AccessToken;
+import com.google.auth.Credentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
-public class GoogleCloudStorageClient extends GoogleCloudClient {
+public class GoogleCloudStorageClient extends GoogleCloudClient<Storage> {
 
-	public static enum StorageScope implements GoogleCloudOAuth.Scope {
+	public static enum StorageScope implements Scope {
 
 		READ_ONLY("https://www.googleapis.com/auth/devstorage.read_only"),
 		READ_WRITE("https://www.googleapis.com/auth/devstorage.read_write"),
@@ -27,28 +26,25 @@ public class GoogleCloudStorageClient extends GoogleCloudClient {
 		}
 	}
 
-	public GoogleCloudStorageClient(final AccessToken accessToken) {
+	private final String projectId;
 
-		super(accessToken);
+	public GoogleCloudStorageClient(final Credentials credentials) {
+
+		this(credentials, null);
 	}
 
-	public GoogleCloudStorageClient(final AccessToken accessToken, final GoogleClientSecrets clientSecrets, final String refreshToken) {
+	public GoogleCloudStorageClient(final Credentials credentials, final String projectId) {
 
-		super(accessToken, clientSecrets, refreshToken);
+		super(credentials);
+		this.projectId = projectId;
 	}
 
+	@Override
 	public Storage create() {
 
-		return createStorageClientBuilder().build().getService();
-	}
-
-	public Storage create(final String projectId) {
-
-		return createStorageClientBuilder().setProjectId(projectId).build().getService();
-	}
-
-	private StorageOptions.Builder createStorageClientBuilder() {
-
-		return StorageOptions.newBuilder().setCredentials(getCredentials());
+		return StorageOptions.newBuilder()
+				.setCredentials(credentials)
+				.setProjectId(projectId)
+				.build().getService();
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/util/SetGoogleCloudClientSecrets.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/util/SetGoogleCloudClientSecrets.java
@@ -1,0 +1,22 @@
+package org.janelia.saalfeldlab.googlecloud.util;
+
+import java.io.IOException;
+
+import org.janelia.saalfeldlab.googlecloud.GoogleCloudClientSecretsProvider;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets.Details;
+
+public class SetGoogleCloudClientSecrets {
+
+	public static void main(final String[] args) throws IOException {
+
+		final String clientId = args[ 0 ], clientSecret = args[ 1 ];
+		final GoogleClientSecrets googleClientSecrets = new GoogleClientSecrets();
+		final Details googleClientSecretsDetails = new Details();
+		googleClientSecretsDetails.setClientId(clientId);
+		googleClientSecretsDetails.setClientSecret(clientSecret);
+		googleClientSecrets.setInstalled(googleClientSecretsDetails);
+		GoogleCloudClientSecretsProvider.save(googleClientSecrets);
+	}
+}

--- a/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/N5GoogleCloudStorageOAuth2Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/N5GoogleCloudStorageOAuth2Test.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.UUID;
 
+import org.janelia.saalfeldlab.googlecloud.GoogleCloudClientSecretsProvider;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudOAuth;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudResourceManagerClient;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageClient;
@@ -53,16 +54,11 @@ public class N5GoogleCloudStorageOAuth2Test extends AbstractN5Test {
 						GoogleCloudResourceManagerClient.ProjectsScope.READ_ONLY,
 						GoogleCloudStorageClient.StorageScope.READ_WRITE
 					),
-				"n5-test-oauth2",
-				N5GoogleCloudStorageOAuth2Test.class.getResourceAsStream("/client_secrets.json")
+				GoogleCloudClientSecretsProvider.load()
 			);
 
 		// query a list of user's projects first
-		final ResourceManager resourceManager = new GoogleCloudResourceManagerClient(
-				oauth.getAccessToken(),
-				oauth.getClientSecrets(),
-				oauth.getRefreshToken()
-			).create();
+		final ResourceManager resourceManager = new GoogleCloudResourceManagerClient(oauth.getCredentials()).create();
 
 		final Iterator<Project> projectsIterator = resourceManager.list().iterateAll().iterator();
 		if (!projectsIterator.hasNext())
@@ -71,11 +67,7 @@ public class N5GoogleCloudStorageOAuth2Test extends AbstractN5Test {
 		// get first project id to run tests
 		final String projectId = projectsIterator.next().getProjectId();
 
-		final Storage storage = new GoogleCloudStorageClient(
-				oauth.getAccessToken(),
-				oauth.getClientSecrets(),
-				oauth.getRefreshToken()
-			).create(projectId);
+		final Storage storage = new GoogleCloudStorageClient(oauth.getCredentials(), projectId).create();
 
 		return new N5GoogleCloudStorageWriter(storage, testBucketName);
 	}

--- a/src/test/resources/client_secrets.json
+++ b/src/test/resources/client_secrets.json
@@ -1,6 +1,0 @@
-{
-  "installed": {
-    "client_id": "Enter Client ID",
-    "client_secret": "Enter Client Secret"
-  }
-}


### PR DESCRIPTION
Add support for storing client secrets in a user-specified file, or in the default location `$user.home/.google/n5-google-cloud`.