### PR TITLE
Credential provider

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/CredentialProvider.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/CredentialProvider.java
@@ -1,0 +1,38 @@
+package org.janelia.saalfeldlab.googlecloud;
+
+import java.io.IOException;
+
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
+import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
+
+/**
+ *
+ * Provide {@link Credential}. This interface allows callers to replace
+ * {@link AuthorizationCodeInstalledApp} with their own provider (that
+ * does not rely on awt).
+ *
+ * @author Philipp Hanslovsky
+ *
+ */
+public interface CredentialProvider
+{
+
+	/**
+	 *
+	 * build {@link Credential from} {@link AuthorizationCodeFlow}
+	 *
+	 * @param flow
+	 * @return
+	 * @throws IOException
+	 */
+	public Credential fromFlow( AuthorizationCodeFlow flow ) throws IOException;
+
+	/**
+	 * Default fall-back to {@link AuthorizationCodeInstalledApp}.
+	 */
+	public static CredentialProvider DEFAULT_PROVIDER =
+			flow -> new AuthorizationCodeInstalledApp( flow, new LocalServerReceiver() ).authorize( "user" );
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudClientSecretsPrompt.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudClientSecretsPrompt.java
@@ -18,7 +18,7 @@ public abstract class GoogleCloudClientSecretsPrompt {
 
 	public abstract GoogleClientSecrets prompt(final GoogleCloudClientSecretsPromptReason reason) throws GoogleCloudSecretsPromptCanceledException;
 
-	protected static GoogleClientSecrets create(final String clientId, final String clientSecret) {
+	public static GoogleClientSecrets create(final String clientId, final String clientSecret) {
 
 		final GoogleClientSecrets googleClientSecrets = new GoogleClientSecrets();
 		final Details googleClientSecretsDetails = new Details();


### PR DESCRIPTION
The `CredentialProvider` interface allows callers to specify how to provide `Credential` instead of relying on `AuthorizationCodeInstalledApp`, which uses awt and clashes with JavaFX