### PR TITLE
Use try/except instead of Files.exists as trigger for client secrets prompt

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudOAuth.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudOAuth.java
@@ -1,5 +1,6 @@
 package org.janelia.saalfeldlab.googlecloud;
 
+import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -74,7 +75,7 @@ public class GoogleCloudOAuth {
 		GoogleClientSecrets temporarySecrets = null;
 		try {
 			temporarySecrets = loadClientSecrets(clientSecretsLocation);
-		} catch (final IllegalArgumentException illegalArgument) {
+		} catch (final IllegalArgumentException | FileNotFoundException exception) {
 			try {
 				temporarySecrets = clientSecretsPrompt.prompt(GoogleCloudClientSecretsPromptReason.NOT_FOUND);
 				saveClientSecrets(clientSecretsLocation, temporarySecrets);


### PR DESCRIPTION
Fixes #6 

Up for discussion:
catghing `IllegalArgumentException` is not very specific (unfortunately, the google API does not thorw a more specific exception). We could
 1. be ok with being not very specific, or
 2. check the message of the exception for `no JSON input found`, which is very fragile.

I favor (1).