### PR TITLE
Use system credentials by default

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudClient.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudClient.java
@@ -1,28 +1,16 @@
 package org.janelia.saalfeldlab.googlecloud;
 
-import com.google.auth.Credentials;
-import com.google.auth.oauth2.GoogleCredentials;
-
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Map;
 
 public abstract class GoogleCloudClient<T> {
 
-	protected final Credentials credentials;
+	public GoogleCloudClient() {
 
-	public GoogleCloudClient(final Credentials credentials) {
-
-		this.credentials = credentials;
+		suppressCredentialsWarning();
 	}
 
 	public abstract T create();
-
-	public static Credentials getSystemCredentials() throws IOException {
-
-		suppressCredentialsWarning();
-		return GoogleCredentials.getApplicationDefault();
-	}
 
 	/**
 	 * Google Cloud SDK prints a warning about authenticating using end user credentials instead of service accounts.

--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudResourceManagerClient.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudResourceManagerClient.java
@@ -1,21 +1,14 @@
 package org.janelia.saalfeldlab.googlecloud;
 
-import com.google.auth.Credentials;
 import com.google.cloud.resourcemanager.ResourceManager;
 import com.google.cloud.resourcemanager.ResourceManagerOptions;
 
 public class GoogleCloudResourceManagerClient extends GoogleCloudClient<ResourceManager> {
 
-	public GoogleCloudResourceManagerClient(final Credentials credentials) {
-
-		super(credentials);
-	}
-
 	@Override
 	public ResourceManager create() {
 
 		return ResourceManagerOptions.newBuilder()
-				.setCredentials(credentials)
 				.build().getService();
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudStorageClient.java
+++ b/src/main/java/org/janelia/saalfeldlab/googlecloud/GoogleCloudStorageClient.java
@@ -1,6 +1,5 @@
 package org.janelia.saalfeldlab.googlecloud;
 
-import com.google.auth.Credentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
@@ -8,14 +7,13 @@ public class GoogleCloudStorageClient extends GoogleCloudClient<Storage> {
 
 	private final String projectId;
 
-	public GoogleCloudStorageClient(final Credentials credentials) {
+	public GoogleCloudStorageClient() {
 
-		this(credentials, null);
+		this(null);
 	}
 
-	public GoogleCloudStorageClient(final Credentials credentials, final String projectId) {
+	public GoogleCloudStorageClient(final String projectId) {
 
-		super(credentials);
 		this.projectId = projectId;
 	}
 
@@ -23,7 +21,6 @@ public class GoogleCloudStorageClient extends GoogleCloudClient<Storage> {
 	public Storage create() {
 
 		return StorageOptions.newBuilder()
-				.setCredentials(credentials)
 				.setProjectId(projectId)
 				.build().getService();
 	}

--- a/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/backend/BackendGoogleCloudStorageFactory.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/backend/BackendGoogleCloudStorageFactory.java
@@ -16,15 +16,12 @@
  */
 package org.janelia.saalfeldlab.n5.googlecloud.backend;
 
-import com.google.auth.Credentials;
 import com.google.cloud.resourcemanager.Project;
 import com.google.cloud.resourcemanager.ResourceManager;
 import com.google.cloud.storage.Storage;
-import org.janelia.saalfeldlab.googlecloud.GoogleCloudClient;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudResourceManagerClient;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageClient;
 
-import java.io.IOException;
 import java.util.Iterator;
 
 import static org.junit.Assert.fail;
@@ -33,14 +30,12 @@ public class BackendGoogleCloudStorageFactory {
 
     private static Storage storage;
 
-    public static Storage getOrCreateStorage() throws IOException {
+    public static Storage getOrCreateStorage() {
 
         if (storage == null) {
 
-            final Credentials credentials = GoogleCloudClient.getSystemCredentials();
-
             // query a list of user's projects first
-            final ResourceManager resourceManager = new GoogleCloudResourceManagerClient(credentials).create();
+            final ResourceManager resourceManager = new GoogleCloudResourceManagerClient().create();
 
             final Iterator<Project> projectsIterator = resourceManager.list().iterateAll().iterator();
             if (!projectsIterator.hasNext())
@@ -49,7 +44,7 @@ public class BackendGoogleCloudStorageFactory {
             // get first project id to run tests
             final String projectId = projectsIterator.next().getProjectId();
 
-            storage = new GoogleCloudStorageClient(credentials, projectId).create();
+            storage = new GoogleCloudStorageClient(projectId).create();
         }
 
         return storage;

--- a/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/backend/N5GoogleCloudStorageBucketRootBackendTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/backend/N5GoogleCloudStorageBucketRootBackendTest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  */
 public class N5GoogleCloudStorageBucketRootBackendTest extends AbstractN5GoogleCloudStorageBucketRootTest {
 
-    public N5GoogleCloudStorageBucketRootBackendTest() throws IOException {
+    public N5GoogleCloudStorageBucketRootBackendTest() {
 
         super(BackendGoogleCloudStorageFactory.getOrCreateStorage());
     }

--- a/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/backend/N5GoogleCloudStorageContainerPathBackendTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/backend/N5GoogleCloudStorageContainerPathBackendTest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  */
 public class N5GoogleCloudStorageContainerPathBackendTest extends AbstractN5GoogleCloudStorageContainerPathTest {
 
-    public N5GoogleCloudStorageContainerPathBackendTest() throws IOException {
+    public N5GoogleCloudStorageContainerPathBackendTest() {
 
         super(BackendGoogleCloudStorageFactory.getOrCreateStorage());
     }


### PR DESCRIPTION
Simplify credential management and do not explicitly create them as the system default credentials will be used by default implicitly anyway. Previously the caller would need to obtain the system credentials via another method and then pass them to the client.