### PR TITLE
Fix createGroup() to not create folders outside the container

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/googlecloud/N5GoogleCloudStorageWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/googlecloud/N5GoogleCloudStorageWriter.java
@@ -157,10 +157,11 @@ public class N5GoogleCloudStorageWriter extends N5GoogleCloudStorageReader imple
 	@Override
 	public void createGroup(final String pathName) throws IOException {
 
-		final Path path = Paths.get(getFullPath(pathName));
-		for (int i = 0; i < path.getNameCount(); ++i) {
-			final String subgroup = path.subpath(0, i + 1).toString();
-			writeBlob(replaceBackSlashes(addTrailingSlash(removeLeadingSlash(subgroup))), null);
+		final Path groupPath = Paths.get(removeLeadingSlash(pathName));
+		for (int i = 0; i < groupPath.getNameCount(); ++i) {
+			final String parentGroupPath = groupPath.subpath(0, i + 1).toString();
+			final String fullParentGroupPath = getFullPath(parentGroupPath);
+			writeBlob(replaceBackSlashes(addTrailingSlash(removeLeadingSlash(fullParentGroupPath))), null);
 		}
 	}
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/AbstractN5GoogleCloudStorageContainerPathTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/AbstractN5GoogleCloudStorageContainerPathTest.java
@@ -43,7 +43,7 @@ public abstract class AbstractN5GoogleCloudStorageContainerPathTest extends Abst
 
         rampDownAfterClass();
         Assert.assertNotNull(storage.get(testBucketName));
-        Assert.assertNotNull(storage.get(testBucketName, "test/"));
+        Assert.assertNull(storage.get(testBucketName, "test/"));
         new N5GoogleCloudStorageWriter(storage, testBucketName).remove();
         Assert.assertNull(storage.get(testBucketName));
     }

--- a/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/mock/N5GoogleCloudStorageContainerPathMockTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/googlecloud/mock/N5GoogleCloudStorageContainerPathMockTest.java
@@ -41,7 +41,7 @@ public class N5GoogleCloudStorageContainerPathMockTest extends AbstractN5GoogleC
 
         // override with more relaxed assertions because mock library does not support bucket creation and deletion
         rampDownAfterClass();
-        Assert.assertNotNull(storage.get(testBucketName, "test/"));
+        Assert.assertNull(storage.get(testBucketName, "test/"));
         Assert.assertTrue(new N5GoogleCloudStorageWriter(storage, testBucketName).remove());
     }
 }


### PR DESCRIPTION
Similar to https://github.com/saalfeldlab/n5-aws-s3/pull/6

There are no real folders in Google Cloud Storage, and the official way to mimic them is to create an empty object ending with `/`. This is what we're doing in `createGroup()` to actually create intermediate groups along the path to the requested group, such as `a/` and `a/b/` for the group `/a/b/c`.
This is not necessary, and the method `exists()` actually uses a different way of checking whether a group exists or not, but for other use-cases it could be quite useful to create intermediate directories explicitly.

The current implementation of `createGroup()` tries to create all directories in the path starting from the bucket root. But if the container is located not at the bucket root but somewhere at a deeper level, such as `s3://bucket/dir/container.n5`, we do not want to attempt to write outside the container, i.e. the bucket root and the directory `dir` should not be modified. Sometimes it may not be even possible, for example, if the user is authorized to work only with the given container and doesn't have write access to the rest of the bucket. This PR fixes this, so that the directories outside the container are not modified.